### PR TITLE
fix: ts-jest[ts-compiler] (WARN) Using hybrid module kind (Node16/18/…

### DIFF
--- a/packages/common-config/tsconfig.nodenext.json
+++ b/packages/common-config/tsconfig.nodenext.json
@@ -11,6 +11,7 @@
         "target": "ES2022",
         "module": "NodeNext",
         "esModuleInterop": true,
-        "resolveJsonModule": true
+        "resolveJsonModule": true,
+        "isolatedModules": true,
     }
 }


### PR DESCRIPTION
…Next) is only supported in "isolatedModules: true". Please set "isolatedModules: true" in your tsconfig.json.